### PR TITLE
Search improvements

### DIFF
--- a/widget/search_panel.vala
+++ b/widget/search_panel.vala
@@ -41,7 +41,7 @@ namespace Widgets {
         
         public SearchPanel(Widgets.ConfigWindow config_window, Term term, string init_search_text) {
             terminal = term;
-            search_text = "";
+            search_text = init_search_text;
             
             search_image = new ImageButton("search", true);
             search_entry = new Widgets.Entry();
@@ -86,6 +86,8 @@ namespace Widgets {
                         
                     if (keyname == "Esc") {
                         quit_search();
+                    } else if (keyname == "Enter") {
+                        update_search_text();
                     }
                         
                     return false;
@@ -113,12 +115,6 @@ namespace Widgets {
                 });
             search_entry.activate.connect((w) => {
                     if (search_text != "") {
-                        terminal.term.search_find_next();
-                    }
-                });
-            search_entry.changed.connect((w) => {
-                    if (search_text != "") {
-                        update_search_text();
                         terminal.term.search_find_next();
                     }
                 });


### PR DESCRIPTION
- allow to search with enter key and previous/next buttons even after initial search panel opening
- disabled live search


Ok, what's wrong with the current code.

type command in your version of terminal: 
```
cat /proc/cpuinfo
```

Then select any word and press search hotkey Ctrl+Shift+F and press next/previous arrow icon or Enter key on keyboard. Search not working, right? That's the problem. 

Problem number 2. While you see the command output from the previous `cat` command open up search box with hotkey again and type "proce". Then type another key "proces". Then another "process". Notice that every time you are entering a character you search position in a view changes even when the search position is completely right. I mean when you pressed "proce" terminal found word "processor" for you. Then you pressed another key and the terminal jumped from that word to another word "processor" that located in the terminal too. It is a real pain when I have a loooong terminal output in a workspace.