### PR TITLE
Revert "Menu was replaced with Gtk.Menu"

### DIFF
--- a/lib/constant.vala
+++ b/lib/constant.vala
@@ -52,7 +52,7 @@ public class Constant {
     public static int THEME_BUTTON_WIDTH = 190;
     public static int THEME_SLIDER_WIDTH = 230;
     public static int TITLEBAR_HEIGHT = 39;
-    public static int WINDOW_BUTTON_WIDTH = 27;
+    public static int WINDOW_BUTTON_WIDHT = 27;
     public static int EXIT_CODE_BAD_SMABA = 139;
     public static int EXIT_CODE_NORMAL = 0;
 }                         

--- a/lib/menu.vala
+++ b/lib/menu.vala
@@ -20,8 +20,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-using Gtk;
-using Gdk;
 
 namespace Menu {
     [DBus (name = "com.deepin.menu.Manager")]
@@ -55,18 +53,11 @@ namespace Menu {
 
 	public class Menu : Object {
 		MenuInterface menu_interface;
-		public List<MenuItem> menu_content;
-		public MenuItem? search_submenu;
-
-		public bool config_theme_is_light = false;
-		public bool is_gtk_menu = false;
-		public Gtk.Menu? gtk_menu;
-		public Gtk.Menu? gtk_search_submenu;
 
 		public signal void click_item(string item_id);
 		public signal void destroy();
 
-		public Menu(bool light_theme) {
+		public Menu(int menu_x, int menu_y, List<MenuItem> menu_content) {
 			try {
 			    MenuManagerInterface menu_manager_interface = Bus.get_proxy_sync(BusType.SESSION, "com.deepin.menu", "/com/deepin/menu");
 			    string menu_object_path = menu_manager_interface.RegisterMenu();
@@ -78,96 +69,14 @@ namespace Menu {
 				menu_interface.MenuUnregistered.connect(() => {
 						destroy();
 					});
-			} catch (Error e) {
+			} catch (IOError e) {
 				stderr.printf ("%s\n", e.message);
-				is_gtk_menu = true;
-				create_gtk_menu();
 			}
 
-			config_theme_is_light = light_theme;
-			menu_content = new List<MenuItem>();
+			show_menu(menu_x, menu_y, menu_content);
 		}
 
-		public void create_gtk_menu() {
-			Gdk.Screen screen = Gdk.Screen.get_default();
-            CssProvider provider = new Gtk.CssProvider();
-            try {
-                provider.load_from_data(Utils.get_menu_css());
-            } catch (GLib.Error e) {
-                    warning("Something bad happened with CSS load %s", e.message);
-            }
-            Gtk.StyleContext.add_provider_for_screen(screen,provider,Gtk.STYLE_PROVIDER_PRIORITY_USER);
-            gtk_menu = new Gtk.Menu();
-            gtk_menu.get_style_context().add_class("gtk_menu");
-            gtk_menu.destroy.connect(handle_gtk_menu_destroy);
-		}
-
-		public void create_submenu(string item_id, string item_text) {
-            if (is_gtk_menu) {
-                gtk_search_submenu = new Gtk.Menu();
-                var item = new Gtk.MenuItem.with_label(item_text);
-                if (!config_theme_is_light)
-                    item.get_style_context().add_class("gtk_menu_item");
-                else
-                    item.get_style_context().add_class("gtk_menu_item_light");
-
-                item.activate.connect(() => {
-                    click_item(item_id);
-                });
-                item.set_submenu(gtk_search_submenu);
-                gtk_menu.append(item);
-            } else {
-                search_submenu = new MenuItem(item_id, item_text);
-                append(search_submenu);
-            }
-        }
-
-        public void add_submenu_item(string item_id, string item_text) {
-            if (is_gtk_menu) {
-                var item = new Gtk.MenuItem.with_label(item_text);
-                if(item_text == "") {
-                    item = new Gtk.SeparatorMenuItem();
-                }
-                if (!config_theme_is_light) 
-                    item.get_style_context().add_class("gtk_menu_item");
-                else 
-                    item.get_style_context().add_class("gtk_menu_item_light");
-
-                item.activate.connect(() => { 
-                    click_item(item_id); 
-                });
-                gtk_search_submenu.add(item);
-            } else {
-                search_submenu.add_submenu_item(new MenuItem(item_id, item_text));
-            }
-        }
-
-		public void append(MenuItem menu_item) {
-			if (is_gtk_menu) {
-				var item = new Gtk.MenuItem.with_label(menu_item.menu_item_text);
-                if(menu_item.menu_item_text == "") {
-                    item = new Gtk.SeparatorMenuItem();
-                }
-                if (!config_theme_is_light) 
-                    item.get_style_context().add_class("gtk_menu_item");
-                else 
-                    item.get_style_context().add_class("gtk_menu_item_light");
-
-                item.activate.connect(() => { 
-                    click_item(menu_item.menu_item_id); 
-                });
-                gtk_menu.append(item);
-			} else {
-				menu_content.append(menu_item);
-			}
-		}
-
-	    public void show_menu(int x, int y) {
-	    	if (is_gtk_menu) {
-	    		show_gtk_menu(x, y);
-	    		return;
-	    	}
-
+	    public void show_menu(int x, int y, List<MenuItem> menu_content) {
 			// since GTK only supports integral scaling yet DDE supports fractional scaling,
 			// the scale on both sides may not be the same, so we need to negtiate here.
 			var scale = Utils.get_default_monitor_scale();
@@ -207,15 +116,6 @@ namespace Menu {
 	    	} catch (IOError e) {
 	    		stderr.printf ("%s\n", e.message);
 	    	}
-	    }
-
-	    public void show_gtk_menu(int x, int y) {
-	    	gtk_menu.show_all();
-	    	Gtk.Allocation menu_rect = Gtk.Allocation();
-	    	menu_rect.x = x;
-	    	menu_rect.y = y;
-	    	gtk_menu.popup_at_rect (Gdk.Screen.get_default().get_root_window(), menu_rect, Gravity.NORTH_WEST, Gravity.NORTH_WEST, null);
-            gtk_menu = null;
 	    }
 
 	    public string get_items_node(List<MenuItem> menu_content) {
@@ -294,10 +194,5 @@ namespace Menu {
 
 	        return builder.get_root();
 	    }
-
-	    public void handle_gtk_menu_destroy() {
-        	search_submenu = null;
-        	gtk_search_submenu = null;
-		}
 	}
 }

--- a/lib/utils.vala
+++ b/lib/utils.vala
@@ -105,51 +105,6 @@ namespace Utils {
         return b;
     }
 
-    public string get_menu_css() {
-            Config.Config config = new Config.Config();
-            string background_color = null;
-            string foreground_color = null;
-            try {
-                background_color = config.config_file.get_string("theme", "background");
-                foreground_color = config.config_file.get_string("theme", "foreground");
-            } catch (GLib.KeyFileError e) {
-                print("Can't read config file: %s\n", e.message);
-                background_color = "#ffffff";
-                foreground_color = "#000000";
-            }
-
-            return @"
-                    .window-frame {
-                        box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22);
-                    }
-                    .window-frame.csd.popup {
-                        box-shadow: 0 19px 38px rgba(0, 0, 0, 0.3), 0 15px 12px rgba(0, 0, 0, 0.22), 0 0 0 1px rgba(0, 0, 0, 0.2);
-                    }
-                    .gtk_menu{
-                        background: $background_color;
-                        border: none;
-                        border-top: 0px solid rgba(0, 0, 0, 0.4);
-                    }
-                    .gtk_menu_item{
-                        background: $background_color;
-                    }
-                    .gtk_menu_item:hover{
-                        background-color: $foreground_color;
-                        color:black;
-                        transition: color 10ms linear;
-                    }
-                    .gtk_menu_item_light{
-                        color:black;
-                        background: $background_color;
-                    }
-                    .gtk_menu_item_light:hover{
-                        background-color: $foreground_color;
-                        color:white;
-                        transition: color 10ms linear;
-                    }
-                    ";
-        }
-
     public void touch_dir(string dir) {
         var dir_file = GLib.File.new_for_path(dir);
         if (!dir_file.query_exists()) {

--- a/widget/entry_menu.vala
+++ b/widget/entry_menu.vala
@@ -21,38 +21,36 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */ 
 
-using Menu;
+using Gtk;
 using Utils;
 
 namespace Widgets {
     public class EntryMenu : Object {
-        public bool config_theme_is_light = false;
-        public Menu.Menu? menu;
+        public Menu.Menu menu;
         
         public EntryMenu() {
             Intl.bindtextdomain(GETTEXT_PACKAGE, "/usr/share/locale");
         }
 
         public void create_entry_menu(Gtk.Entry entry, int x, int y) {
-            menu = new Menu.Menu(config_theme_is_light);
-            menu.click_item.connect((item_id) => {
-                handle_menu_item_click(entry, item_id);
-            });
-            menu.destroy.connect(handle_menu_destroy);
-
+            var menu_content = new List<Menu.MenuItem>();
             if (is_selection(entry)) {
-                menu.append(new Menu.MenuItem("cut", _("Cut")));
-                menu.append(new Menu.MenuItem("copy", _("Copy")));
+                menu_content.append(new Menu.MenuItem("cut", _("Cut")));
+                menu_content.append(new Menu.MenuItem("copy", _("Copy")));
             }
-            menu.append(new Menu.MenuItem("paste", _("Paste")));
-            menu.append(new Menu.MenuItem("", ""));
+            menu_content.append(new Menu.MenuItem("paste", _("Paste")));
+            menu_content.append(new Menu.MenuItem("", ""));
             if (is_selection(entry)) {
-                menu.append(new Menu.MenuItem("delete", _("Delete")));
-                menu.append(new Menu.MenuItem("", ""));
+                menu_content.append(new Menu.MenuItem("delete", _("Delete")));
+                menu_content.append(new Menu.MenuItem("", ""));
             }
-            menu.append(new Menu.MenuItem("select_all", _("Select all")));
+            menu_content.append(new Menu.MenuItem("select_all", _("Select all")));
                         
-            menu.show_menu(x, y);
+            menu = new Menu.Menu(x, y, menu_content);
+            menu.click_item.connect((item_id) => {
+                    handle_menu_item_click(entry, item_id);
+                });
+            menu.destroy.connect(handle_menu_destroy);
         }
 
         public void handle_menu_item_click(Gtk.Entry entry, string item_id) {
@@ -73,10 +71,6 @@ namespace Widgets {
                     entry.select_region(0, -1);
                     break;
             }
-        }
-
-        public void handle_menu_destroy() {
-            menu = null;
         }        
             
         public bool is_selection(Gtk.Entry entry) {
@@ -84,6 +78,10 @@ namespace Widgets {
             entry.get_selection_bounds(out start_pos, out end_pos);
                 
             return start_pos != end_pos;
+        }
+            
+        public void handle_menu_destroy() {
+            menu = null;
         }
     }
 }

--- a/widget/terminal.vala
+++ b/widget/terminal.vala
@@ -43,8 +43,8 @@ namespace Widgets {
         public Gdk.RGBA background_color = Gdk.RGBA();
         public Gdk.RGBA foreground_color = Gdk.RGBA();
         public Gtk.Scrollbar scrollbar;
+        public Menu.Menu menu;
         public Terminal term;
-        public Menu.Menu? menu;
         public WorkspaceManager workspace_manager;
         public bool child_has_exit = false;
         public bool has_print_exit_notify = false;
@@ -66,6 +66,7 @@ namespace Widgets {
         public string? server_info;
         public uint launch_idle_id;
         public uint? hide_scrollbar_timeout_source_id = null;
+
         public static string USERCHARS = "-[:alnum:]";
         public static string USERCHARS_CLASS = "[" + USERCHARS + "]";
         public static string PASSCHARS_CLASS = "[-[:alnum:]\\Q,?;.:/!%$^*&~\"#'\\E]";
@@ -325,14 +326,7 @@ namespace Widgets {
             return in_remote_server;
         }
 
-        private void create_menu() {
-            menu = new Menu.Menu(((Widgets.ConfigWindow) get_toplevel()).is_light_theme());
-            menu.click_item.connect(handle_menu_item_click);
-            menu.destroy.connect(handle_menu_destroy);
-        }
-
         public void show_menu(int x, int y) {
-            create_menu();
             bool in_quake_window = this.get_toplevel().get_type().is_a(typeof(Widgets.QuakeWindow));
 
             // Set variable 'show_quake_menu' to true if terminal's window is quake window.
@@ -344,24 +338,26 @@ namespace Widgets {
 
             bool display_first_spliter = false;
 
+            var menu_content = new GLib.List<Menu.MenuItem>();
             if (term.get_has_selection()) {
-                menu.append(new Menu.MenuItem("copy", _("Copy")));
+                menu_content.append(new Menu.MenuItem("copy", _("Copy")));
+
                 display_first_spliter = true;
             } else if (uri_at_right_press != null) {
-                menu.append(new Menu.MenuItem("copy", _("Copy link")));
+                menu_content.append(new Menu.MenuItem("copy", _("Copy link")));
 
                 display_first_spliter = true;
             }
 
             if (clipboard_has_context()) {
-                menu.append(new Menu.MenuItem("paste", _("Paste")));
+                menu_content.append(new Menu.MenuItem("paste", _("Paste")));
 
                 display_first_spliter = true;
             }
             if (term.get_has_selection()) {
                 var selection_file = get_selection_file();
                 if (selection_file != null) {
-                    menu.append(new Menu.MenuItem("open", _("Open")));
+                    menu_content.append(new Menu.MenuItem("open", _("Open")));
                 }
 
                 display_first_spliter = true;
@@ -369,51 +365,52 @@ namespace Widgets {
             if (current_dir != "") {
 				var dir_file = GLib.File.new_for_path(current_dir);
 				if (dir_file.query_exists()) {
-					menu.append(new Menu.MenuItem("open_in_filemanager", _("Open in file manager")));
+					menu_content.append(new Menu.MenuItem("open_in_filemanager", _("Open in file manager")));
 				}
 				
 				display_first_spliter = true;
             }
 
             if (display_first_spliter) {
-                menu.append(new Menu.MenuItem("", ""));
+                menu_content.append(new Menu.MenuItem("", ""));
             }
-            menu.append(new Menu.MenuItem("horizontal_split", _("Horizontal split")));
-            menu.append(new Menu.MenuItem("vertical_split", _("Vertical split")));
-            menu.append(new Menu.MenuItem("close_window", _("Close window")));
-            if (workspace_manager.focus_workspace.term_list.size > 1) {
-                menu.append(new Menu.MenuItem("close_other_windows", _("Close other windows")));
-            }
-            menu.append(new Menu.MenuItem("", ""));
 
-            menu.append(new Menu.MenuItem("new_workspace", _("New workspace")));
-            menu.append(new Menu.MenuItem("", ""));
+            menu_content.append(new Menu.MenuItem("horizontal_split", _("Horizontal split")));
+            menu_content.append(new Menu.MenuItem("vertical_split", _("Vertical split")));
+            menu_content.append(new Menu.MenuItem("close_window", _("Close window")));
+            if (workspace_manager.focus_workspace.term_list.size > 1) {
+                menu_content.append(new Menu.MenuItem("close_other_windows", _("Close other windows")));
+            }
+            menu_content.append(new Menu.MenuItem("", ""));
+
+            menu_content.append(new Menu.MenuItem("new_workspace", _("New workspace")));
+            menu_content.append(new Menu.MenuItem("", ""));
 
             if (!in_quake_window) {
                 var window = ((Widgets.Window) get_toplevel());
                 if (window.window_is_fullscreen()) {
-                    menu.append(new Menu.MenuItem("quit_fullscreen", _("Exit fullscreen")));
+                    menu_content.append(new Menu.MenuItem("quit_fullscreen", _("Exit fullscreen")));
                 } else {
-                    menu.append(new Menu.MenuItem("fullscreen", _("Fullscreen")));
+                    menu_content.append(new Menu.MenuItem("fullscreen", _("Fullscreen")));
                 }
             }
 
-            menu.append(new Menu.MenuItem("find", _("Find")));
-            menu.append(new Menu.MenuItem("", ""));
+            menu_content.append(new Menu.MenuItem("find", _("Find")));
+            menu_content.append(new Menu.MenuItem("", ""));
             if (term.get_has_selection()) {
-                menu.create_submenu("search", _("Search"));
+                Menu.MenuItem online_search  = new Menu.MenuItem("search", _("Search"));
 
-                menu.add_submenu_item("google", "Google");
-                menu.add_submenu_item("bing", "Bing");
+                online_search.add_submenu_item(new Menu.MenuItem("google", "Google"));
+                online_search.add_submenu_item(new Menu.MenuItem("bing", "Bing"));
 
                 string? lang = Environment.get_variable("LANG");
                 if (lang != null && lang == "zh_CN.UTF-8") {
-                    menu.add_submenu_item("baidu", "Baidu");
+                    online_search.add_submenu_item(new Menu.MenuItem("baidu", "Baidu"));
                 }
 
-                menu.add_submenu_item("github", "Github");
-                menu.add_submenu_item("stackoverflow", "Stack Overflow");
-                menu.add_submenu_item("duckduckgo", "DuckDuckGo");
+                online_search.add_submenu_item(new Menu.MenuItem("github", "Github"));
+                online_search.add_submenu_item(new Menu.MenuItem("stackoverflow", "Stack Overflow"));
+                online_search.add_submenu_item(new Menu.MenuItem("duckduckgo", "DuckDuckGo"));
 
                 var file = File.new_for_path(search_engine_config_file_path);
                 if (file.query_exists()) {
@@ -425,7 +422,7 @@ namespace Widgets {
                             string search_engine_api = search_engine_config_file.get_value(option, "api");
 
                             if (search_engine_name != "" && search_engine_api != "") {
-                                menu.add_submenu_item(option, search_engine_name);
+                                online_search.add_submenu_item(new Menu.MenuItem(option, search_engine_name));
                             }
                         }
                     } catch (Error e) {
@@ -434,23 +431,30 @@ namespace Widgets {
                         }
                     }
                 }
+
+                menu_content.append(online_search);
             }
-            menu.append(new Menu.MenuItem("", ""));
-            menu.append(new Menu.MenuItem("switch_theme", _("Switch theme")));
-            menu.append(new Menu.MenuItem("rename_title", _("Rename title")));
-            menu.append(new Menu.MenuItem("encoding", _("Encoding")));
-            menu.append(new Menu.MenuItem("custom_commands", _("Custom commands")));
-            menu.append(new Menu.MenuItem("remote_manage", _("Remote management")));
+            menu_content.append(new Menu.MenuItem("", ""));
+            if (in_quake_window) {
+                menu_content.append(new Menu.MenuItem("switch_theme", _("Switch theme")));
+            }
+            menu_content.append(new Menu.MenuItem("rename_title", _("Rename title")));
+            menu_content.append(new Menu.MenuItem("encoding", _("Encoding")));
+            menu_content.append(new Menu.MenuItem("custom_commands", _("Custom commands")));
+            menu_content.append(new Menu.MenuItem("remote_manage", _("Remote management")));
             if (is_in_remote_server()) {
-                menu.append(new Menu.MenuItem("", ""));
-                menu.append(new Menu.MenuItem("upload_file", _("Upload file")));
-                menu.append(new Menu.MenuItem("download_file", _("Download file")));
+                menu_content.append(new Menu.MenuItem("", ""));
+                menu_content.append(new Menu.MenuItem("upload_file", _("Upload file")));
+                menu_content.append(new Menu.MenuItem("download_file", _("Download file")));
             }
 
-            menu.append(new Menu.MenuItem("", ""));
-            menu.append(new Menu.MenuItem("preference", _("Settings")));
+            menu_content.append(new Menu.MenuItem("", ""));
+            menu_content.append(new Menu.MenuItem("preference", _("Settings")));
 
-            menu.show_menu(x, y);
+            menu = new Menu.Menu(x, y, menu_content);
+            menu.click_item.connect(handle_menu_item_click);
+            menu.destroy.connect(handle_menu_destroy);
+
         }
 
         public void handle_menu_item_click(string item_id) {

--- a/widget/window_button.vala
+++ b/widget/window_button.vala
@@ -121,7 +121,7 @@ namespace Widgets {
     }
 
     public WindowButton create_close_button() {
-        var close_button = new WindowButton("titlebar_close", false, Constant.WINDOW_BUTTON_WIDTH + Constant.CLOSE_BUTTON_MARGIN_RIGHT, Constant.TITLEBAR_HEIGHT);
+        var close_button = new WindowButton("titlebar_close", false, Constant.WINDOW_BUTTON_WIDHT + Constant.CLOSE_BUTTON_MARGIN_RIGHT, Constant.TITLEBAR_HEIGHT);
         close_button.set_halign(Gtk.Align.END);
         
         return close_button;


### PR DESCRIPTION
Reverts linuxdeepin/deepin-terminal#47

After apply patch, have many new bugs:
1、right click quickly, have many deepin-menu popup and throw unexpected error: GDBus.Error:org.freedesktop.DBus.Error.UnknownObject: No such object path '/com/deepin/menu/c9c9bf07_c877_46b6_b9e4_95509c9b4ee8' (g-dbus-error-quark, 41) 

2、show menu coordinate is not right when main menu at click right-top of window 