### PR TITLE
Change default 'rename title shortcut' from F2 to another key #86

### DIFF
--- a/lib/config.vala
+++ b/lib/config.vala
@@ -108,7 +108,7 @@ namespace Config {
                 config_file.set_string("shortcut", "close_window", "Ctrl + Alt + q");
                 config_file.set_string("shortcut", "close_other_windows", "Ctrl + Shift + q");
 
-                config_file.set_string("shortcut", "rename_title", "F2");
+                config_file.set_string("shortcut", "rename_title", "Alt + t");
                 config_file.set_string("shortcut", "switch_fullscreen", "F11");
                 config_file.set_string("shortcut", "display_shortcuts", "Ctrl + Shift + ?");
                 config_file.set_string("shortcut", "custom_commands", "Ctrl + [");


### PR DESCRIPTION
I am using 3.0.12 Deepin Terminal with 15.8 Deepin desktop Linux.

When I am using mcedit the save shortcut is F2. Then I want to save and type F2 instead of saving the terminal shows the tab rename dialog. I have changed the default shortcut to nothing but could you change this shortcut to another key by default?