### PR TITLE
Resizeable workspaces

### DIFF
--- a/lib/config.vala
+++ b/lib/config.vala
@@ -306,6 +306,12 @@ namespace Config {
             check_string("shortcut", "close_workspace", "Ctrl + Shift + w");
             check_string("shortcut", "next_workspace", "Ctrl + Tab");
             check_string("shortcut", "previous_workspace", "Ctrl + Shift + Tab");
+
+            check_string("shortcut", "resize_workspace_up", "Ctrl + Alt + Up");
+            check_string("shortcut", "resize_workspace_down", "Ctrl + Alt + Down");
+            check_string("shortcut", "resize_workspace_left", "Ctrl + Alt + Left");
+            check_string("shortcut", "resize_workspace_right", "Ctrl + Alt + Right");
+
             check_string("shortcut", "vertical_split", "Ctrl + Shift + j");
             check_string("shortcut", "horizontal_split", "Ctrl + Shift + h");
             check_string("shortcut", "select_upper_window", "Alt + k");

--- a/widget/config_window.vala
+++ b/widget/config_window.vala
@@ -471,6 +471,30 @@ namespace Widgets {
                     return true;
                 }
 
+                var resize_workspace_left_key = config.config_file.get_string("shortcut", "resize_workspace_left");
+                if (resize_workspace_left_key != "" && keyname == resize_workspace_left_key) {
+                    workspace_manager.focus_workspace.resize_workspace_left();
+                    return true;
+                }
+
+                var resize_workspace_right_key = config.config_file.get_string("shortcut", "resize_workspace_right");
+                if (resize_workspace_right_key != "" && keyname == resize_workspace_right_key) {
+                    workspace_manager.focus_workspace.resize_workspace_right();
+                    return true;
+                }
+
+                var resize_workspace_up_key = config.config_file.get_string("shortcut", "resize_workspace_up");
+                if (resize_workspace_up_key != "" && keyname == resize_workspace_up_key) {
+                    workspace_manager.focus_workspace.resize_workspace_up();
+                    return true;
+                }
+
+                var resize_workspace_down_key = config.config_file.get_string("shortcut", "resize_workspace_down");
+                if (resize_workspace_down_key != "" && keyname == resize_workspace_down_key) {
+                    workspace_manager.focus_workspace.resize_workspace_down();
+                    return true;
+                }
+
                 var split_vertically_key = config.config_file.get_string("shortcut", "vertical_split");
                 if (split_vertically_key != "" && keyname == split_vertically_key) {
                     workspace_manager.focus_workspace.remove_all_panels();

--- a/widget/workspace.vala
+++ b/widget/workspace.vala
@@ -55,6 +55,10 @@ namespace Widgets {
         public int show_slider_start_x;
         public uint? highlight_frame_timeout_source_id = null;
 
+        private enum WorkspaceResizeKey {
+            LEFT, RIGHT, UP, DOWN
+        }
+
         public signal void change_title(int index, string dir);
         public signal void exit(int index);
         public signal void highlight_tab(int index);
@@ -818,6 +822,50 @@ namespace Widgets {
             if (focus_terminal != null) {
                 focus_terminal.focus_term();
             }
+        }
+
+        private void resize_workspace(Term term, WorkspaceResizeKey key) {
+            Paned paned = (Paned) term.get_parent();
+
+            // Trying to find needed paned widget with correct orientation. So for left/right keys paned should have horizontal orientation
+            var correct_paned_found = is_paned_correct(paned, key);
+
+            while (paned.get_parent().get_type().is_a(typeof(Paned)) && !correct_paned_found) {
+                    paned = (Paned) paned.get_parent();
+                    correct_paned_found = is_paned_correct(paned, key);
+            }
+
+            if (!correct_paned_found) return;
+
+            int value = 0;
+            if (key == WorkspaceResizeKey.LEFT || key == WorkspaceResizeKey.UP)
+                value = -20;
+            else //key == WorkspaceResizeKey.RIGHT || key == WorkspaceResizeKey.DOWN
+                value = 20;
+
+            int pos = paned.get_position() + value;
+            paned.set_position(pos);
+        }
+
+        private bool is_paned_correct(Paned paned, WorkspaceResizeKey key) {
+            return ((key == WorkspaceResizeKey.LEFT || key == WorkspaceResizeKey.RIGHT) && paned.get_orientation() == Gtk.Orientation.HORIZONTAL) 
+            ||  ((key == WorkspaceResizeKey.UP || key == WorkspaceResizeKey.DOWN) && paned.get_orientation() == Gtk.Orientation.VERTICAL);
+        }
+
+        public void resize_workspace_left() {
+            resize_workspace (get_focus_term(this), WorkspaceResizeKey.LEFT);
+        }
+
+        public void resize_workspace_right() {
+            resize_workspace (get_focus_term(this), WorkspaceResizeKey.RIGHT);
+        }
+
+        public void resize_workspace_up() {
+            resize_workspace (get_focus_term(this), WorkspaceResizeKey.UP);
+        }
+
+        public void resize_workspace_down() {
+            resize_workspace (get_focus_term(this), WorkspaceResizeKey.DOWN);
         }
 
         public void remove_all_panels() {


### PR DESCRIPTION
Added useful feature which allows to resize workspaces using keyboard.
Default hotkeys are: Ctrl + Alt + Up/Down/Left/Right. For me these keys are ok.
Next PR will be for tab bar at the bottom of the screen and tiling WM support. Are you ok if I'll remove Deepin logo from a view when tabbar location=bottom?