### PR TITLE
fix: avoid using dpkg-parsechangelog

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -2,9 +2,8 @@
 %:
 	dh $@ 
 
-VERSION ?= $(shell dpkg-parsechangelog -SVersion | awk -F'[+-]' '{print $$1}')
 override_dh_auto_configure:
-	cmake -DVERSION=${VERSION} -DCMAKE_INSTALL_PREFIX=/usr -DTEST_BUILD=OFF .
+	cmake -DVERSION=${DEB_VERSION_UPSTREAM} -DCMAKE_INSTALL_PREFIX=/usr -DTEST_BUILD=OFF .
 
 override_dh_clean:
 	rm -fr CMakeFiles CMakeCache.txt cmake_install.cmake install_manifest.txt Makefile project_path.c || true


### PR DESCRIPTION
linuxdeepin/internal-discussion#866