### PR TITLE
refactor: include default.mk for debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,6 @@
 #!/usr/bin/make -f
+include /usr/share/dpkg/default.mk
+
 %:
 	dh $@ 
 


### PR DESCRIPTION
Which is missing in #113