### PR TITLE
feat: config option for bold_is_bright

### DIFF
--- a/lib/config.vala
+++ b/lib/config.vala
@@ -332,6 +332,7 @@ namespace Config {
             check_string("advanced", "cursor_shape", "block");
             check_boolean("advanced", "cursor_blink_mode", true);
             check_boolean("advanced", "cursor_auto_hide", false);
+            check_boolean("advanced", "bold_is_bright", false);
 
             check_boolean("advanced", "scroll_on_key", true);
             check_boolean("advanced", "scroll_on_output", false);

--- a/widget/terminal.vala
+++ b/widget/terminal.vala
@@ -1302,6 +1302,8 @@ namespace Widgets {
                     term.set_cursor_blink_mode(Vte.CursorBlinkMode.OFF);
                 }
 
+                term.set_bold_is_bright(parent_window.config.config_file.get_boolean("advanced", "bold_is_bright"));
+
                 term.set_mouse_autohide(parent_window.config.config_file.get_boolean("advanced", "cursor_auto_hide"));
 
                 var scroll_lines = parent_window.config.config_file.get_integer("advanced", "scroll_line");


### PR DESCRIPTION
Config:

`bold_is_bright=false` under `[advanced]` section, from file `~/.config/deepin/deepin-terminal/config.conf`.

Task-Id: linuxdeepin/developer-center#1042
Change-Id: Ibeaeb0a3b1e99a438aac0415765e01e43465c129