### PR TITLE
fix: receive it when the mouse event is useful

### DIFF
--- a/widget/window.vala
+++ b/widget/window.vala
@@ -189,6 +189,7 @@ namespace Widgets {
                                 pointer_x *= get_scale_factor();
                                 pointer_y *= get_scale_factor();
                                 resize_window(this, pointer_x, pointer_y, (int) e.button, cursor_type);
+                                return true;
                             }
                         }
                     }
@@ -206,6 +207,7 @@ namespace Widgets {
                             pointer_x *= get_scale_factor();
                             pointer_y *= get_scale_factor();
                             resize_window(this, pointer_x, pointer_y, (int) e.button, cursor_type);
+                            return true;
                         }
                     }
 


### PR DESCRIPTION
fix mouse vicious grab when resize window on kwin

https://github.com/linuxdeepin/internal-discussion/issues/1328

修复resize窗口时界面卡住，操作鼠标和键盘都失效