### PR TITLE
fix: download file opened dialog should modal parent

### DIFF
--- a/widget/terminal.vala
+++ b/widget/terminal.vala
@@ -617,7 +617,8 @@ namespace Widgets {
 
         public void download_file() {
             Gtk.FileChooserAction action = Gtk.FileChooserAction.SELECT_FOLDER;
-            var chooser = new Gtk.FileChooserDialog(_("Select directory to save the file"), null, action);
+            var chooser = new Gtk.FileChooserDialog(_("Select directory to save the file"), 
+                                                    get_toplevel() as Gtk.Window, action);
             chooser.add_button(_("Cancel"), Gtk.ResponseType.CANCEL);
             chooser.add_button(_("Select"), Gtk.ResponseType.ACCEPT);
 


### PR DESCRIPTION
taskID=5474

终端远程管理下载文件时，弹出的文管选择对话框需始终置顶显示