### PR TITLE
add a resize grip line to make non-composited wm user can resize the terminal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ Some tiling WM user may prefer let the tabbar at the window bottom, set `tabbar_
 #### audible_bell
 Controls whether or not the terminal will beep when the child outputs the "bl" sequence. Default is `false`.
 
+#### always_hide_resize_grip
+When you are using deepin-terminal with not composited window manager, there will be a resize grip line at the bottom of the window for resizing the window. To disable the extra resize grip line, set `always_hide_resize_grip` to true.
+
 ## Customize themes
 User can place its own theme file to `~/.config/deepin/deepin-terminal/themes` (create if path not exist), the theme file added to this location will available to use from the theme selection panel.
 

--- a/image/resize_grip.svg
+++ b/image/resize_grip.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="8"
+   height="8"
+   viewBox="0 0 8 8"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="resize_grip.svg"
+   inkscape:version="0.92.1 r15371">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="66.75088"
+     inkscape:cx="4.373029"
+     inkscape:cy="5.3314098"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g6" />
+  <g
+     id="g6"
+     transform="rotate(-45.229347,-45.152817,15.312598)"
+     style="fill:none;fill-rule:evenodd">
+    <rect
+       width="40"
+       height="40"
+       id="rect2"
+       x="0"
+       y="0"
+       style="fill:#34344b;fill-opacity:0" />
+    <polygon
+       points="25,20 25,19 24.529,19 15.471,19 15,19 15,20 15.471,20 24.529,20 "
+       id="polygon4"
+       style="fill:#2ca7f8;fill-opacity:0.61;fill-rule:nonzero"
+       transform="translate(-22.50611,22.713108)" />
+    <polygon
+       points="25,19 24.529,19 15.471,19 15,19 15,20 15.471,20 24.529,20 25,20 "
+       id="polygon4-3"
+       style="fill:#2ca7f8;fill-opacity:0.61000001;fill-rule:nonzero"
+       transform="matrix(0.61960837,0,0,0.61960837,-14.911079,32.35785)" />
+    <polygon
+       points="25,20 25,19 24.529,19 15.471,19 15,19 15,20 15.471,20 24.529,20 "
+       id="polygon4-3-6"
+       style="fill:#2ca7f8;fill-opacity:0.61000001;fill-rule:nonzero"
+       transform="matrix(0.28172919,0,0,0.28172919,-8.17074,40.799488)" />
+  </g>
+</svg>

--- a/lib/config.vala
+++ b/lib/config.vala
@@ -140,6 +140,7 @@ namespace Config {
                 config_file.set_boolean("advanced", "copy_on_select", false);
                 config_file.set_boolean("advanced", "tabbar_at_the_bottom", false);
                 config_file.set_boolean("advanced", "audible_bell", false);
+                config_file.set_boolean("advanced", "always_hide_resize_grip", false);
 
                 config_file.set_string("theme", "color_1", "#073642");
                 config_file.set_comment("theme", "color_1", "host");
@@ -336,6 +337,7 @@ namespace Config {
             check_boolean("advanced", "cursor_auto_hide", false);
             check_boolean("advanced", "bold_is_bright", false);
             check_boolean("advanced", "audible_bell", false);
+            check_boolean("advanced", "always_hide_resize_grip", false);
 
             check_boolean("advanced", "scroll_on_key", true);
             check_boolean("advanced", "scroll_on_output", false);

--- a/main.vala
+++ b/main.vala
@@ -255,6 +255,7 @@ public class Application : Object {
                 tabbar.init(workspace_manager, quake_window);
             } else {
                 window = new Widgets.Window(window_mode);
+                window.set_has_resize_grip(true);
 
                 // Change theme temporary if 'load_theme' option is valid.
                 if (load_theme != null) {

--- a/widget/resize_grip.vala
+++ b/widget/resize_grip.vala
@@ -24,6 +24,9 @@
 using Gtk;
 using Widgets;
 
+// This is pretty dirty workaround to make the window resizable under not composited window manager.
+// Feel free to submit a patch if you have better solution.
+
 namespace Widgets {
     private static int GRIP_WIDTH = 8;
     public static int GRIP_HEIGHT = 8;
@@ -52,7 +55,7 @@ namespace Widgets {
             });
 
             leave_notify_event.connect((w, e) => {
-
+                // set cursor back.
                 get_window().set_cursor(null);
 
                 return false;

--- a/widget/resize_grip.vala
+++ b/widget/resize_grip.vala
@@ -1,0 +1,118 @@
+/* -*- Mode: Vala; indent-tabs-mode: nil; tab-width: 4 -*-
+ * -*- coding: utf-8 -*-
+ *
+ * Copyright (C) 2019 Deepin, Inc.
+ *               2019 Gary Wang
+ *
+ * Author:     Gary Wang <wzc782970009@gmail.com>
+ * Maintainer: Gary Wang <wzc782970009@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+using Gtk;
+using Widgets;
+
+namespace Widgets {
+    private static int GRIP_WIDTH = 8;
+    public static int GRIP_HEIGHT = 8;
+
+    public class Grip : Gtk.EventBox {
+
+        public Cairo.ImageSurface resize_grip_surface;
+        public int surface_y;
+
+        public signal void clicked(Gdk.EventButton event);
+
+        public Grip() {
+
+            resize_grip_surface = Utils.create_image_surface("resize_grip.svg");
+            set_size_request(GRIP_WIDTH, GRIP_HEIGHT);
+            surface_y = (GRIP_HEIGHT - resize_grip_surface.get_height() / get_scale_factor()) / 2;
+
+            draw.connect(on_draw);
+
+            enter_notify_event.connect((w, e) => {
+                // set cursor.
+                get_window().set_cursor(new Gdk.Cursor.for_display(Gdk.Display.get_default(),
+                                                                   Gdk.CursorType.BOTTOM_RIGHT_CORNER));
+
+                return false;
+            });
+
+            leave_notify_event.connect((w, e) => {
+
+                get_window().set_cursor(null);
+
+                return false;
+            });
+
+            button_press_event.connect((w, e) => {
+                get_window().begin_resize_drag(Gdk.WindowEdge.SOUTH_EAST, (int)e.button, (int)e.x_root, (int)e.y_root, e.get_time());
+
+                return false;
+            });
+        }
+
+        private bool on_draw(Gtk.Widget widget, Cairo.Context cr) {
+            Draw.draw_surface(cr, resize_grip_surface, 0, surface_y);
+
+            return true;
+        }
+    }
+
+    public class ResizeGrip : Gtk.Overlay {
+        public Widgets.WindowEventArea event_area;
+        public Widgets.Window window;
+        public Grip grip;
+
+        public ResizeGrip(Widgets.Window win) {
+
+            window = win;
+
+            grip = new Widgets.Grip();
+            grip.set_halign(Gtk.Align.END);
+
+            Box box = new Box(Gtk.Orientation.HORIZONTAL, 0);
+            box.pack_start(grip, true, true, 0);
+
+            event_area = new Widgets.WindowEventArea(this);
+            event_area.margin_end = Constant.CLOSE_BUTTON_WIDTH;
+
+            add(box);
+            add_overlay(event_area);
+
+            set_size_request(-1, GRIP_HEIGHT);
+
+            Gdk.RGBA background_color = Gdk.RGBA();
+
+            box.draw.connect((w, cr) => {
+                Gtk.Allocation rect;
+                w.get_allocation(out rect);
+
+                try {
+                    background_color = Utils.hex_to_rgba(window.config.config_file.get_string("theme", "background"));
+                    cr.set_source_rgba(background_color.red, background_color.green, background_color.blue, window.config.config_file.get_double("general", "opacity"));
+                    Draw.draw_rectangle(cr, 0, 0, rect.width, rect.height);
+                } catch (Error e) {
+                    print("ResizeGrip draw: %s\n", e.message);
+                }
+
+                Utils.propagate_draw((Container) w, cr);
+
+                return true;
+            });
+        }
+    }
+}

--- a/widget/window.vala
+++ b/widget/window.vala
@@ -459,7 +459,7 @@ namespace Widgets {
                 get_window().set_shadow_width(window_frame_margin_start, window_frame_margin_end, window_frame_margin_top, window_frame_margin_bottom);
             }
 
-            if (Utils.is_tiling_wm() || screen_monitor.is_composited() || window_is_fullscreen() || window_is_max()) {
+            if (Utils.is_tiling_wm() || screen_monitor.is_composited() || window_is_fullscreen() || window_is_max() || config.config_file.get_boolean("advanced", "always_hide_resize_grip")) {
                 resize_grip.hide();
             } else {
                 resize_grip.show();

--- a/widget/window.vala
+++ b/widget/window.vala
@@ -27,6 +27,7 @@ using Gtk;
 using Utils;
 using Wnck;
 using XUtils;
+using Widgets;
 
 namespace Widgets {
     public class Window : Widgets.ConfigWindow {
@@ -50,6 +51,8 @@ namespace Widgets {
         public int window_widget_margin_start = 2;
         public int window_widget_margin_top = 1;
         public int window_width;
+        
+        private Widgets.ResizeGrip resize_grip;
 
         public Window(string? window_mode) {
             tabbar_at_the_bottom = config.config_file.get_boolean("advanced", "tabbar_at_the_bottom");
@@ -455,6 +458,12 @@ namespace Widgets {
 
                 get_window().set_shadow_width(window_frame_margin_start, window_frame_margin_end, window_frame_margin_top, window_frame_margin_bottom);
             }
+
+            if (Utils.is_tiling_wm() || screen_monitor.is_composited() || window_is_fullscreen() || window_is_max()) {
+                resize_grip.hide();
+            } else {
+                resize_grip.show();
+            }
         }
 
         public void toggle_max() {
@@ -686,6 +695,7 @@ namespace Widgets {
             }
 
             var overlay = new Gtk.Overlay();
+            resize_grip = new Widgets.ResizeGrip(this);
             top_box.pack_start(fullscreen_box, false, false, 0);
             if (tabbar_at_the_bottom) {
                 box.pack_start(workspace_manager, true, true, 0);
@@ -694,6 +704,7 @@ namespace Widgets {
             else {
                 box.pack_start(top_box, false, false, 0);
                 box.pack_start(workspace_manager, true, true, 0);
+                box.pack_start(resize_grip, false, false, 0);
             }
 
             overlay.add(box);


### PR DESCRIPTION
assoc: https://github.com/linuxdeepin/deepin-terminal/issues/173

This is a little dirty patch to add a resize grip line to the terminal window if composited is not enabled, which allow user resize the window by draging the resize grip. Feel free to submit a patch if anyone have better way to implement it (eg, allow drag the window border to resize window from the client-side, without wm support).