### PR TITLE
[Tabbar] align active underline with terminal

### DIFF
--- a/widget/quake_window.vala
+++ b/widget/quake_window.vala
@@ -410,7 +410,7 @@ namespace Widgets {
             }
 
             draw_titlebar_underline(cr, x, titlebar_y + height - Constant.TITLEBAR_HEIGHT - 1, width, -1);
-            draw_active_tab_underline(cr, x + active_tab_underline_x, titlebar_y + height - Constant.TITLEBAR_HEIGHT - 1);
+            draw_active_tab_underline(cr, x + active_tab_underline_x, titlebar_y + height - Constant.TITLEBAR_HEIGHT);
         }
 
         public void show_window(WorkspaceManager workspace_manager, Tabbar tabbar) {

--- a/widget/tabbar.vala
+++ b/widget/tabbar.vala
@@ -467,7 +467,7 @@ namespace Widgets {
                     cr.save();
                     clip_rectangle(cr, draw_x, 0, tab_width, height);
 
-                    update_tab_underline(draw_x, tab_width + 1);
+                    update_tab_underline(draw_x + 1, tab_width - 1);
 
                     cr.restore();
 

--- a/widget/window.vala
+++ b/widget/window.vala
@@ -547,7 +547,7 @@ namespace Widgets {
                             if (tabbar_at_the_bottom) 
                                 draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, titlebar_y + height - Constant.TITLEBAR_HEIGHT - 1);
                             else 
-                                draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, titlebar_y +  Constant.TITLEBAR_HEIGHT);
+                                draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, titlebar_y +  Constant.TITLEBAR_HEIGHT - 1);
                         }
                     } else if (window_is_max() || window_is_tiled()) {
                         int titlebar_y = y;
@@ -559,7 +559,7 @@ namespace Widgets {
                         if (tabbar_at_the_bottom) 
                             draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, titlebar_y + height - Constant.TITLEBAR_HEIGHT - 1);
                         else 
-                            draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, titlebar_y + Constant.TITLEBAR_HEIGHT + 1);
+                            draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, titlebar_y + Constant.TITLEBAR_HEIGHT - 1);
                     } else {
                         // Draw line above at titlebar.
                         cr.set_source_rgba(frame_color.red, frame_color.green, frame_color.blue, config.config_file.get_double("general", "opacity"));
@@ -602,7 +602,7 @@ namespace Widgets {
                         if (tabbar_at_the_bottom) 
                             draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, y + height - Constant.TITLEBAR_HEIGHT - 1);
                         else 
-                            draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, y + Constant.TITLEBAR_HEIGHT);
+                            draw_active_tab_underline(cr, x + active_tab_underline_x - window_frame_box.margin_start, y + Constant.TITLEBAR_HEIGHT -1);
                     }
                 } catch (Error e) {
                     print("Window draw_window_above: %s\n", e.message);


### PR DESCRIPTION
Issue: #158

Screenshot below shows the new behavior. Left is current right is the new implementation.

![DeepinScreenshot_select-area_20190728160031](https://user-images.githubusercontent.com/7502104/62007865-d2962280-b152-11e9-9e17-c666352810ae.png)
