### PR TITLE
Gtk Menu styling

### DIFF
--- a/lib/menu.vala
+++ b/lib/menu.vala
@@ -21,6 +21,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+using Gtk;
+
 namespace Menu {
     [DBus (name = "com.deepin.menu.Manager")]
     interface MenuManagerInterface : Object {
@@ -121,6 +123,14 @@ namespace Menu {
         }
 
         private Gtk.Menu create_gtk_menu(List<MenuItem> menu_content) {
+            Gdk.Screen screen = Gdk.Screen.get_default();
+            CssProvider provider = new Gtk.CssProvider();
+            try {
+                provider.load_from_data(Utils.get_menu_css());
+            } catch (GLib.Error e) {
+                    warning("Something bad happened with CSS load %s", e.message);
+            }
+            Gtk.StyleContext.add_provider_for_screen(screen,provider,Gtk.STYLE_PROVIDER_PRIORITY_USER);
             Gtk.Menu result = new Gtk.Menu();
             
             foreach (unowned MenuItem menu_item in menu_content) {

--- a/lib/utils.vala
+++ b/lib/utils.vala
@@ -129,6 +129,40 @@ namespace Utils {
         is_tiling = true;
     }
 
+    public string get_menu_css() {
+        string background_color = "#ffffff";
+        string foreground_color = "#000000";
+        bool is_light_theme = true;
+        try {
+            Config.Config config = new Config.Config();
+            background_color = config.config_file.get_string("theme", "background");
+            foreground_color = config.config_file.get_string("theme", "foreground");
+            is_light_theme = config.config_file.get_string("theme", "style") == "light";
+        } catch (GLib.KeyFileError e) {
+            print("Can't read config file: %s\n", e.message);
+        }
+        string text_color = is_light_theme ? "white" : "black";
+        string text_color_on_hover = is_light_theme ? "black" : "white";
+
+        return @"
+            menu {
+                background: $background_color;
+                opacity: 0.95;
+                border: 0;
+            }
+            menu menuitem{
+                color: $text_color_on_hover;
+                background: $background_color;
+                opacity: 0.95;
+            }
+            menu menuitem:hover {
+                background-color: $foreground_color;
+                color: $text_color;
+                transition: color 10ms linear;
+            }
+            ";
+    }
+
     public void touch_dir(string dir) {
         var dir_file = GLib.File.new_for_path(dir);
         if (!dir_file.query_exists()) {


### PR DESCRIPTION
Hello. This is a new version of my old PR related to adding support of Gtk menu. Deepin menu is working fine for those users who has /usr/bin/deepin-menu dependency installed.
So if you have deepin-menu you'll see deepin menu. Otherwise you'll see Gtk implementation of menu.

To check this PR remove deepin menu (you don't even need to restart your terminal) and make a right click of a mouse. Gtk implementation will appear. To return things back install deepin menu again.

If you're asking why it's needed:
- menu in this PR can adjust it's colors based on a terminal theme. Dark & light themes supported
- deepin menu is buggy (current implementation is not hiding with click on non-menu space of a window)
- deepin menu needs many useless dependencies for non-deepin users
- gtk menu is fast.

I tried to make the code look clean but if you have another vision of a good code tell me and I'll make it better.

What's good and what's bad in the PR:
+ coloring
+ universal submenu
+ menu in settings

- menu under the top right button has bad positioning (as well as with tabbar_at_the_bottom option enabled). I don't now how to get correct position for the menu close to the button location. Will investigate it
- also I think we should remove the top right menu because it useless (except Start new terminal and About options but we can move them into right click menu)
- I don't have anything except XFCE and i3wm so I'm not sure it works everywhere
- do I need to make submenu = null? Or memory will be freed automatically since I don't have hard references on submenus?

Share your thoughts about this PR, please. Also I think we can remove deepin-menu dependency from packages afterwards because Deepin users will have it anyway from DE components.

P.S. For now It's not ready for merging because of the right menu location.