### PR TITLE
fix: Add force tiling mode for x-windows like VcXsrv

### DIFF
--- a/lib/utils.vala
+++ b/lib/utils.vala
@@ -122,6 +122,11 @@ namespace Utils {
         return is_tiling;
     }
 
+    public void set_tiling_wm() {
+        tiling_checked = true;
+        is_tiling = true;
+    }
+
     public void touch_dir(string dir) {
         var dir_file = GLib.File.new_for_path(dir);
         if (!dir_file.query_exists()) {

--- a/main.vala
+++ b/main.vala
@@ -117,7 +117,7 @@ public class Application : Object {
         }
 
         try {
-            string window_mode_description = "%s (normal, maximize, fullscreen)".printf(_("Set the terminal window mode"));
+            string window_mode_description = "%s (normal, maximize, fullscreen, tiling)".printf(_("Set the terminal window mode"));
 
             GLib.OptionEntry[] pass_options = {
                 OptionEntry() {
@@ -254,6 +254,11 @@ public class Application : Object {
             Gtk.main_quit();
         } else {
             Utils.load_css_theme(Utils.get_root_path("style.css"));
+
+            if (window_mode == "tiling") {
+                // fix x-windows like VcXsrv
+                Utils.set_tiling_wm();
+            }
 
             Tabbar tabbar = new Tabbar();
             workspace_manager = new WorkspaceManager(tabbar, work_directory);


### PR DESCRIPTION
I use VcXsrv in windows WSL. `is_tiling_wm` use `pidof` can't check it.

Run cmd like this:
```
deepin-terminal -m tiling
```