### PR TITLE
vala: fix build with latest vte3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ option(USE_VENDOR_LIB "Backport support for debian stretch" ON)
 
 if (NOT USE_VENDOR_LIB)
 pkg_check_modules(VTE REQUIRED vte-2.91)
+# There're 3 releases for 0.59.x, only 0.59.0 keeps old behaviour
+if("${VTE_VERSION}" VERSION_GREATER "0.59.0")
+    list(APPEND ARGS_DEFINITIONS "VTE_0_60")
+endif()
 endif()
 
 if (NOT DEFINED VERSION)

--- a/lib/utils.vala
+++ b/lib/utils.vala
@@ -607,7 +607,13 @@ namespace Utils {
         return command;
     }
 
+#if VTE_0_60
+    public uint8[] to_raw_data(string str) {
+        return str.data;
+    }
+#else
     public char[] to_raw_data(string str) {
         return str.to_utf8();
     }
+#endif
 }

--- a/lib/utils.vala
+++ b/lib/utils.vala
@@ -606,4 +606,8 @@ namespace Utils {
 
         return command;
     }
+
+    public char[] to_raw_data(string str) {
+        return str.to_utf8();
+    }
 }

--- a/widget/command_panel.vala
+++ b/widget/command_panel.vala
@@ -299,7 +299,7 @@ namespace Widgets {
         public void execute_command(string command) {
             Term focus_term = workspace_manager.focus_workspace.get_focus_term(workspace_manager.focus_workspace);
             var command_string = "%s\n".printf(command);
-            focus_term.term.feed_child(command_string.to_utf8());
+            focus_term.term.feed_child(Utils.to_raw_data(command_string));
 
             workspace.hide_command_panel();
             if (focus_widget != null) {

--- a/widget/terminal.vala
+++ b/widget/terminal.vala
@@ -611,7 +611,7 @@ namespace Widgets {
                         }
                         upload_command = upload_command + "\n";
 
-                        this.term.feed_child(upload_command.to_utf8());
+                        this.term.feed_child(Utils.to_raw_data(upload_command));
 
                         return false;
                     });
@@ -639,7 +639,7 @@ namespace Widgets {
                         GLib.Timeout.add(100, () => {
                                 // NOTE: Use quote around $file to avoid escape filepath.
                                 string command = "read -e -a files -p \"%s: \"; sz \"${files[@]}\"\n".printf(_("Type path to download file"));
-                                this.term.feed_child(command.to_utf8());
+                                this.term.feed_child(Utils.to_raw_data(command));
 
                                 enter_sz_command = true;
 
@@ -684,17 +684,17 @@ namespace Widgets {
                     GLib.Timeout.add(100, () => {
                             // Switch directory in zssh.
                             string switch_command = "cd %s\n".printf(save_file_directory);
-                            this.term.feed_child(switch_command.to_utf8());
+                            this.term.feed_child(Utils.to_raw_data(switch_command));
 
                             // Do rz command to download file.
                             GLib.Timeout.add(100, () => {
                                     string download_command = "rz\n";
-                                    this.term.feed_child(download_command.to_utf8());
+                                    this.term.feed_child(Utils.to_raw_data(download_command));
 
                                     // Press enter automatically.
                                     GLib.Timeout.add(100, () => {
                                             string enter_command = "\n";
-                                            this.term.feed_child(enter_command.to_utf8());
+                                            this.term.feed_child(Utils.to_raw_data(enter_command));
 
                                             return false;
                                         });
@@ -979,7 +979,7 @@ namespace Widgets {
                             foreach (unowned string option in command_config_file.get_groups ()) {
                                 if (keyname == command_config_file.get_value(option, "Shortcut")) {
                                     var command_string = "%s\n".printf(command_config_file.get_value(option, "Command"));
-                                    term.feed_child(command_string.to_utf8());
+                                    term.feed_child(Utils.to_raw_data(command_string));
 
                                     return true;
                                 }
@@ -1090,7 +1090,7 @@ namespace Widgets {
                             }
                             upload_command = upload_command + "\n";
 
-                            this.term.feed_child(upload_command.to_utf8());
+                            this.term.feed_child(Utils.to_raw_data(upload_command));
 
                             return false;
                         });
@@ -1105,7 +1105,7 @@ namespace Widgets {
                     }
 
                     string uris_s = string.joinv("", uris);
-                    this.term.feed_child(uris_s.to_utf8());
+                    this.term.feed_child(Utils.to_raw_data(uris_s));
                 }
 
                 break;
@@ -1114,7 +1114,7 @@ namespace Widgets {
                 var data = selection_data.get_text ();
 
                 if (data != null) {
-                    this.term.feed_child(data.to_utf8());
+                    this.term.feed_child(Utils.to_raw_data(data));
                 }
 
                 break;
@@ -1588,7 +1588,7 @@ namespace Widgets {
                 if (term != null) {
                     string login_command = "expect -f " + tmpfile.get_path() + "\n";
                     expect_file_path = tmpfile.get_path();
-                    term.feed_child(login_command.to_utf8());
+                    term.feed_child(Utils.to_raw_data(login_command));
                 }
             } catch (Error e) {
                 stderr.printf("login_server: %s\n", e.message);

--- a/widget/workspace.vala
+++ b/widget/workspace.vala
@@ -141,7 +141,7 @@ namespace Widgets {
                     if (term_dir.length > 0) {
                         Term new_focus_term = get_focus_term(this);
                         string switch_command = "cd %s\n".printf(term_dir);
-                        new_focus_term.term.feed_child(switch_command.to_utf8());
+                        new_focus_term.term.feed_child(Utils.to_raw_data(switch_command));
                     }
 
                     return false;


### PR DESCRIPTION
In Vala (as of version 0.46.3), string::to_utf8() returns "char[]",
but Terminal::feed_child() expects "unowned uint8[]" instead.

VTE 0.60.0 has changed signature

I don't have much experience with Vala.
Here's a simple fix for this problem.