### PR TITLE
Fix clickable regex for VTE 0.60+

### DIFF
--- a/widget/terminal.vala
+++ b/widget/terminal.vala
@@ -1124,11 +1124,8 @@ namespace Widgets {
         private void clickable (string[] str) {
             foreach (string exp in str) {
                 try {
-                    var regex = new GLib.Regex(exp,
-                                               GLib.RegexCompileFlags.OPTIMIZE |
-                                               GLib.RegexCompileFlags.MULTILINE,
-                                               0);
-                    int id = term.match_add_gregex(regex, 0);
+                    var regex = new Vte.Regex.for_match(exp, -1, 0x00000400u); /* PCRE2_MULTILINE */
+                    int id = term.match_add_regex(regex, 0);
 
                     term.match_set_cursor_type(id, Gdk.CursorType.HAND2);
                 } catch (GLib.RegexError error) {

--- a/widget/terminal.vala
+++ b/widget/terminal.vala
@@ -1124,8 +1124,16 @@ namespace Widgets {
         private void clickable (string[] str) {
             foreach (string exp in str) {
                 try {
+#if VTE_0_60
                     var regex = new Vte.Regex.for_match(exp, -1, 0x00000400u); /* PCRE2_MULTILINE */
                     int id = term.match_add_regex(regex, 0);
+#else
+                    var regex = new GLib.Regex(exp,
+                                               GLib.RegexCompileFlags.OPTIMIZE |
+                                               GLib.RegexCompileFlags.MULTILINE,
+                                               0);
+                    int id = term.match_add_gregex(regex, 0);
+#endif
 
                     term.match_set_cursor_type(id, Gdk.CursorType.HAND2);
                 } catch (GLib.RegexError error) {


### PR DESCRIPTION
The old function was deprecated since VTE 0.46 and breaks since 0.60.